### PR TITLE
Potential fix for code scanning alert no. 39: Information exposure through an exception

### DIFF
--- a/garden_manager/web/blueprints/garden/__init__.py
+++ b/garden_manager/web/blueprints/garden/__init__.py
@@ -302,4 +302,4 @@ def create():
         return render_template("create_plot.html")
     except (sqlite3.Error, ValueError, KeyError) as e:
         print(f"Create plot error: {e}")
-        return f"<h1>Create Plot Error</h1><p>{str(e)}</p>"
+        return "<h1>Create Plot Error</h1><p>An error occurred while creating the plot. Please try again later.</p>"


### PR DESCRIPTION
Potential fix for [https://github.com/zamays/Planted/security/code-scanning/39](https://github.com/zamays/Planted/security/code-scanning/39)

The fix is to avoid returning exception messages (`str(e)`) directly in the HTTP response to the end user. Instead, log the exception using `print()` (or a dedicated logger, if available), and return a generic error message such as "An error occurred while creating the plot."  The changes are limited to the `create` view function in `garden_manager/web/blueprints/garden/__init__.py` at line 305. No changes to imports, and no additional functionality are required. If structured logging is available elsewhere, it could be used in place of `print()`, but `print()` is sufficient for this context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
