### PR TITLE
Potential fix for code scanning alert no. 32: Information exposure through an exception

### DIFF
--- a/garden_manager/web/blueprints/plants/__init__.py
+++ b/garden_manager/web/blueprints/plants/__init__.py
@@ -242,8 +242,8 @@ def add():
 
         return render_template("add_plant.html")
     except (sqlite3.Error, ValueError, KeyError) as e:
-        print(f"Add plant error: {e}")
-        return f"<h1>Add Plant Error</h1><p>{str(e)}</p>"
+        logging.error(f"Add plant error: {e}")
+        return "<h1>Add Plant Error</h1><p>An internal error occurred while adding the plant.</p>"
 
 
 @plants_bp.route("/<int:plant_id>")


### PR DESCRIPTION
Potential fix for [https://github.com/zamays/Planted/security/code-scanning/32](https://github.com/zamays/Planted/security/code-scanning/32)

To fix the problem, you should ensure that detailed error information (such as exception messages) is not exposed to users via the web interface. Instead, log the internal exception message on the server for debugging, and return a generic error message to the user. Specifically:
- In the `add()` view function, edit the exception block (lines 244–247) so that, instead of returning the error message with `str(e)` to the user, the server logs the error, and the rendered message to the user is a generic one (e.g., “An internal error occurred while adding the plant.”).
- Use Python’s `logging` module (already imported and configured!) to log the exception message.
- The change is limited to lines 244–247 in `garden_manager/web/blueprints/plants/__init__.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
