### PR TITLE
Potential fix for code scanning alert no. 38: Information exposure through an exception

### DIFF
--- a/garden_manager/web/blueprints/garden/__init__.py
+++ b/garden_manager/web/blueprints/garden/__init__.py
@@ -255,7 +255,7 @@ def plant_to_plot(plot_id):
         print(f"Plant to plot error: {e}")
 
         traceback.print_exc()
-        return f"<h1>Plant to Plot Error</h1><p>{str(e)}</p>"
+        return "<h1>Plant to Plot Error</h1><p>An internal error occurred while planting to plot. Please try again later.</p>"
 
 
 @garden_bp.route("/create", methods=["GET", "POST"])


### PR DESCRIPTION
Potential fix for [https://github.com/zamays/Planted/security/code-scanning/38](https://github.com/zamays/Planted/security/code-scanning/38)

To fix the issue, we should stop displaying exception details (`str(e)`) to the end user. Instead, a generic error message should be returned, such as "An internal error occurred while planting to plot. Please try again later." Meanwhile, the current logging (printing the actual error and the stack trace) to standard output should be retained (or ideally improved by using proper logging—but keeping as-is since external code edits are off limits) so developers retain access to diagnostic details. Only line(s) returning the error message to the user should be modified to return a generic message.

Edit `garden_manager/web/blueprints/garden/__init__.py`, replacing line(s) in the `except` block of `plant_to_plot` so that the user sees a generic message. Retain all server-side printing/logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
