### PR TITLE
Potential fix for code scanning alert no. 36: Information exposure through an exception

### DIFF
--- a/garden_manager/web/blueprints/garden/__init__.py
+++ b/garden_manager/web/blueprints/garden/__init__.py
@@ -110,7 +110,8 @@ def delete_plot(plot_id):
         return redirect(url_for("garden.index"))
     except (sqlite3.Error, ValueError) as e:
         print(f"Delete plot error: {e}")
-        return f"<h1>Delete Plot Error</h1><p>{str(e)}</p>"
+        traceback.print_exc()
+        return "<h1>Delete Plot Error</h1><p>An internal error occurred while deleting the plot.</p>"
 
 
 def _validate_position_in_bounds(x_pos, y_pos, plot):


### PR DESCRIPTION
Potential fix for [https://github.com/zamays/Planted/security/code-scanning/36](https://github.com/zamays/Planted/security/code-scanning/36)

To resolve the issue, edit the exception handler in the `delete_plot` route (lines 111–113 of garden_manager/web/blueprints/garden/__init__.py). Instead of returning the full error string (`str(e)`) in the response, log the exception server-side and display a generic error message to the user, such as "An internal error occurred while deleting the plot." If you want to retain more information for debugging, consider logging the full stack trace using the `traceback` module (already imported in the file). 

Specifically:
- Change the `except` block to use `traceback.print_exc()` (or log the formatted traceback).
- Return a neutral, non-revealing message in the response HTML.
Only edit the code region shown (lines 111–113) in garden_manager/web/blueprints/garden/__init__.py.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
