### PR TITLE
Potential fix for code scanning alert no. 34: Information exposure through an exception

### DIFF
--- a/garden_manager/web/blueprints/garden/__init__.py
+++ b/garden_manager/web/blueprints/garden/__init__.py
@@ -43,7 +43,7 @@ def index():
         return render_template("garden.html", plots=plots)
     except (sqlite3.Error, AttributeError) as e:
         print(f"Garden error: {e}")
-        return f"<h1>Garden Error</h1><p>{str(e)}</p>"
+        return "<h1>Garden Error</h1><p>An internal error occurred while loading the garden.</p>"
 
 
 @garden_bp.route("/<int:plot_id>")


### PR DESCRIPTION
Potential fix for [https://github.com/zamays/Planted/security/code-scanning/34](https://github.com/zamays/Planted/security/code-scanning/34)

To fix the information exposure problem, the error message displayed to the user should NOT include the raw exception or any stack trace information. Instead, a generic, non-revealing error message should be shown in the HTTP response. Any details about the error, such as the message or stack trace, should be logged server-side for troubleshooting by developers or administrators. 

This requires:
- Replacing the user-facing message on line 46 with a generic error message (no details of `e`).
- Logging the actual exception details to the server log—retaining the existing `print(...)` approach is acceptable for small projects, but ideally, production code should use a proper logging facility.
- No changes are needed elsewhere in the snippet, as error handling in `view_plot()` is already generic and safe.

**Required changes:**
- In `garden_manager/web/blueprints/garden/__init__.py`, revise the `except` block in the `index()` function so users receive only a generic message.
- No need to change the logging for now (`print(f"Garden error: {e}")` is sufficient for this context), though a logging import could be added in the future.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
