### PR TITLE
Potential fix for code scanning alert no. 33: Information exposure through an exception

### DIFF
--- a/garden_manager/web/blueprints/plants/__init__.py
+++ b/garden_manager/web/blueprints/plants/__init__.py
@@ -264,8 +264,8 @@ def detail(plant_id):
 
         return render_template("plant_detail.html", plant=plant)
     except (sqlite3.Error, AttributeError) as e:
-        print(f"Plant detail error: {e}")
-        return f"<h1>Plant Detail Error</h1><p>{str(e)}</p>"
+        logging.error(f"Plant detail error: {e}", exc_info=True)
+        return "<h1>Plant Detail Error</h1><p>An internal error occurred while fetching plant detail.</p>"
 
 
 @plants_bp.route("/<int:plant_id>/edit", methods=["GET", "POST"])


### PR DESCRIPTION
Potential fix for [https://github.com/zamays/Planted/security/code-scanning/33](https://github.com/zamays/Planted/security/code-scanning/33)

The best fix is to replace the error message that includes `str(e)` with a generic error message for the user, ensuring that no sensitive information is leaked to the client. Meanwhile, log the detailed error (including stack trace or exception details) server-side for debugging purposes. 
To do this:
- Change line 268 to return a generic HTML error message, similar to the one used for the `add()` function.
- Add a call to `logging.error(...)` to log the exception on the server.
- Remove or replace the existing `print(...)` statement on line 267 with logging (for consistency with other error handling).
These changes should be applied within the `except` block of the `detail` function in garden_manager/web/blueprints/plants/__init__.py.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
