### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/zamays/Planted/security/code-scanning/1](https://github.com/zamays/Planted/security/code-scanning/1)

To fix the problem, the workflow definition should explicitly specify the minimal permissions required for the job at either the workflow or job level using the `permissions` key. Since the workflow only runs pylint and does not appear to create issues, write to the repository, or otherwise interact with the GitHub API beyond checking out code, the minimal permissions set is `contents: read`. This should be added at the root of the workflow (before `jobs:`) or within the `build` job block. The single best fix is to add the following block right after the workflow name and before the `on:` key in `.github/workflows/pylint.yml`:

```yaml
permissions:
  contents: read
```

This restricts the GITHUB_TOKEN permissions to read-only on repository contents and follows GitHub's least-privilege recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
